### PR TITLE
want to use Katalon-native logging class in Test Cases while messages should be casted into ExtentReports

### DIFF
--- a/Scripts/Extent Report001 using KeywordUtil/Script1713947262025.groovy
+++ b/Scripts/Extent Report001 using KeywordUtil/Script1713947262025.groovy
@@ -1,0 +1,44 @@
+import org.openqa.selenium.WebDriver
+
+import com.kms.katalon.core.configuration.RunConfiguration
+import com.kms.katalon.core.util.KeywordUtil
+import com.kms.katalon.core.webui.driver.DriverFactory
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+
+WebUI.openBrowser('')
+
+KeywordUtil.logInfo('Browser Launched')
+
+WebUI.navigateToUrl('https://www.google.com/')
+
+WebUI.maximizeWindow()
+
+KeywordUtil.logInfo('Navigated to www.google.com')
+
+RunConfiguration.getProjectDir()
+
+WebUI.takeScreenshot('Screenshots/' + 'googleScreenshot.png')
+
+KeywordUtil.logInfo('Snapshot below: ' + TestListenerExtentReport.extentTest.addScreenCapture(RunConfiguration.getProjectDir() + '/Screenshots/googleScreenshot.png'))
+
+// get title.
+String title = WebUI.getWindowTitle()
+
+println(title)
+
+KeywordUtil.logInfo('Get the WebSite title')
+
+// Verify title.
+if (title.equalsIgnoreCase('Google')) {
+    KeywordUtil.markPassed('Title verified')
+} else {
+	StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+	int lineNumber = stackTrace[2].getLineNumber();
+    String dest = CustomKeywords.'com.katalon.plugin.keyword.extentReport.Extent.getScreeshot'(DriverFactory.getWebDriver(), TestListenerExtentReport.execID, "Line:"+lineNumber+"_"+TestListenerExtentReport.testcasename)
+
+    KeywordUtil.markFailed('Error Line : '+ lineNumber + TestListenerExtentReport.extentTest.addScreenCapture(dest))
+}
+
+WebUI.closeBrowser()
+
+KeywordUtil.logInfo('Browser closed')

--- a/Scripts/Extent Report002 using KeywordUtil/Script1713948128748.groovy
+++ b/Scripts/Extent Report002 using KeywordUtil/Script1713948128748.groovy
@@ -1,0 +1,42 @@
+import org.openqa.selenium.WebDriver
+
+import com.kms.katalon.core.configuration.RunConfiguration
+import com.kms.katalon.core.util.KeywordUtil
+import com.kms.katalon.core.webui.driver.DriverFactory
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.relevantcodes.extentreports.ExtentReports
+import com.relevantcodes.extentreports.ExtentTest
+
+WebUI.openBrowser('')
+
+KeywordUtil.logInfo('Browser Launched')
+
+WebUI.navigateToUrl('https://www.gmail.com')
+
+WebUI.maximizeWindow()
+
+KeywordUtil.logInfo('Navigated to www.gmail.com')
+
+RunConfiguration.getProjectDir()
+
+WebUI.takeScreenshot('Screenshots/' + 'gmailScreenshot.png')
+
+KeywordUtil.logInfo('Snapshot below:' + TestListenerExtentReport.extentTest.addScreenCapture(RunConfiguration.getProjectDir() + '/Screenshots/gmailScreenshot.png'))
+
+// get title.
+String title = WebUI.getWindowTitle()
+println(title)
+
+KeywordUtil.logInfo('Get the WebSite title')
+
+if (title.equalsIgnoreCase('Gmail2')) {
+    KeywordUtil.markPassed('Title verified')
+} else {
+	StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+	int lineNumber = stackTrace[2].getLineNumber();
+    String dest = CustomKeywords.'com.katalon.plugin.keyword.extentReport.Extent.getScreeshot'(DriverFactory.getWebDriver(), TestListenerExtentReport.execID, "Line:"+lineNumber+"_"+TestListenerExtentReport.testcasename)
+    KeywordUtil.logInfo('Error Line : '+ lineNumber + TestListenerExtentReport.extentTest.addScreenCapture(dest))
+}
+
+WebUI.closeBrowser()
+KeywordUtil.logInfo('Browser closed')

--- a/Scripts/Extent Report003 using KeywordUtil/Script1713950881290.groovy
+++ b/Scripts/Extent Report003 using KeywordUtil/Script1713950881290.groovy
@@ -1,0 +1,43 @@
+import org.openqa.selenium.WebDriver
+
+import com.kms.katalon.core.configuration.RunConfiguration
+import com.kms.katalon.core.util.KeywordUtil
+import com.kms.katalon.core.webui.driver.DriverFactory
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.relevantcodes.extentreports.ExtentReports
+import com.relevantcodes.extentreports.ExtentTest
+
+WebUI.openBrowser('')
+
+KeywordUtil.logInfo('Browser Launched')
+
+WebUI.navigateToUrl('https://www.katalon.com/')
+
+WebUI.maximizeWindow()
+
+KeywordUtil.logInfo('Navigated to www.katalon.com')
+
+RunConfiguration.getProjectDir()
+
+WebUI.takeScreenshot('Screenshots/' + 'katalonScreenshot.png')
+
+KeywordUtil.logInfo('Snapshot below:' + TestListenerExtentReport.extentTest.addScreenCapture(RunConfiguration.getProjectDir() + '/Screenshots/katalonScreenshot.png'))
+
+// get title.
+String title = WebUI.getWindowTitle()
+
+println(title)
+
+KeywordUtil.logInfo('Get the WebSite title')
+
+if (title.equalsIgnoreCase('Katalon AI-augmented Software Quality Management Platform2')) {
+    KeywordUtil.markPassed('Title verified')
+} else {
+	StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+	int lineNumber = stackTrace[2].getLineNumber();
+    String dest = CustomKeywords.'com.katalon.plugin.keyword.extentReport.Extent.getScreeshot'(DriverFactory.getWebDriver(), TestListenerExtentReport.execID, "Line:"+lineNumber+"_"+TestListenerExtentReport.testcasename)
+    KeywordUtil.markFailed('Error Line : '+ lineNumber+ TestListenerExtentReport.extentTest.addScreenCapture(dest))
+}
+
+WebUI.closeBrowser()
+KeywordUtil.logInfo('Browser closed')

--- a/Test Cases/Extent Report001 using KeywordUtil.tc
+++ b/Test Cases/Extent Report001 using KeywordUtil.tc
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>Extent Report001 using KeywordUtil</name>
+   <tag></tag>
+   <comment></comment>
+   <testCaseGuid>094611be-0bf0-439a-9dfc-5f4ee0ed8a74</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Extent Report002 using KeywordUtil.tc
+++ b/Test Cases/Extent Report002 using KeywordUtil.tc
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>Extent Report002 using KeywordUtil</name>
+   <tag></tag>
+   <comment></comment>
+   <testCaseGuid>a913733e-ddaf-4e2d-98da-a221dfa6758d</testCaseGuid>
+</TestCaseEntity>

--- a/Test Cases/Extent Report003 using KeywordUtil.tc
+++ b/Test Cases/Extent Report003 using KeywordUtil.tc
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestCaseEntity>
+   <description></description>
+   <name>Extent Report003 using KeywordUtil</name>
+   <tag></tag>
+   <comment></comment>
+   <testCaseGuid>90771be0-a10d-4446-9e49-1a9e26cbdde7</testCaseGuid>
+</TestCaseEntity>

--- a/Test Listeners/TestListenerExtentReport.groovy
+++ b/Test Listeners/TestListenerExtentReport.groovy
@@ -10,10 +10,12 @@ import com.kms.katalon.core.annotation.BeforeTestSuite
 import com.kms.katalon.core.configuration.RunConfiguration
 import com.kms.katalon.core.context.TestCaseContext
 import com.kms.katalon.core.context.TestSuiteContext
+import com.kms.katalon.core.util.KeywordUtil
 import com.kms.katalon.core.webui.driver.DriverFactory
 import com.kms.katalon.core.webui.driver.SmartWaitWebDriver
 import com.relevantcodes.extentreports.ExtentReports
 import com.relevantcodes.extentreports.ExtentTest
+import com.relevantcodes.extentreports.LogStatus
 import java.nio.file.Paths;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -30,6 +32,22 @@ class TestListenerExtentReport {
 	public static String execID
 	public static String testcasename
 
+	TestListenerExtentReport() {
+		modifyKeywordUtil()
+	}
+	
+	private void modifyKeywordUtil() {
+		KeywordUtil.metaClass."static".invokeMethod = { String name, args ->
+			if (name == "logInfo") {
+				TestListenerExtentReport.extentTest.log(LogStatus.INFO, args[0])
+			} else if (name == "markPassed") {
+				TestListenerExtentReport.extentTest.log(LogStatus.PASS, args[0])
+			} else if (name == "markFailed") {
+				TestListenerExtentReport.extentTest.log(LogStatus.FAIL, args[0])
+			}
+			return delegate.metaClass.getMetaMethod(name, args).invoke(delegate, args)
+		}
+	}
 	
 	@BeforeTestSuite
 	def deleteHtmlReport() {

--- a/Test Suites/Test Suite using KeywordUtil.groovy
+++ b/Test Suites/Test Suite using KeywordUtil.groovy
@@ -1,0 +1,66 @@
+import static com.kms.katalon.core.checkpoint.CheckpointFactory.findCheckpoint
+import static com.kms.katalon.core.testcase.TestCaseFactory.findTestCase
+import static com.kms.katalon.core.testdata.TestDataFactory.findTestData
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+
+import com.kms.katalon.core.checkpoint.Checkpoint as Checkpoint
+import com.kms.katalon.core.checkpoint.CheckpointFactory as CheckpointFactory
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+import com.kms.katalon.core.testcase.TestCase as TestCase
+import com.kms.katalon.core.testcase.TestCaseFactory as TestCaseFactory
+import com.kms.katalon.core.testdata.TestData as TestData
+import com.kms.katalon.core.testdata.TestDataFactory as TestDataFactory
+import com.kms.katalon.core.testobject.ObjectRepository as ObjectRepository
+import com.kms.katalon.core.testobject.TestObject as TestObject
+
+import com.kms.katalon.core.webservice.keyword.WSBuiltInKeywords as WS
+import com.kms.katalon.core.webui.keyword.WebUiBuiltInKeywords as WebUI
+import com.kms.katalon.core.mobile.keyword.MobileBuiltInKeywords as Mobile
+
+import internal.GlobalVariable as GlobalVariable
+
+import com.kms.katalon.core.annotation.SetUp
+import com.kms.katalon.core.annotation.SetupTestCase
+import com.kms.katalon.core.annotation.TearDown
+import com.kms.katalon.core.annotation.TearDownTestCase
+
+/**
+ * Some methods below are samples for using SetUp/TearDown in a test suite.
+ */
+
+/**
+ * Setup test suite environment.
+ */
+@SetUp(skipped = true) // Please change skipped to be false to activate this method.
+def setUp() {
+	// Put your code here.
+}
+
+/**
+ * Clean test suites environment.
+ */
+@TearDown(skipped = true) // Please change skipped to be false to activate this method.
+def tearDown() {
+	// Put your code here.
+}
+
+/**
+ * Run before each test case starts.
+ */
+@SetupTestCase(skipped = true) // Please change skipped to be false to activate this method.
+def setupTestCase() {
+	// Put your code here.
+}
+
+/**
+ * Run after each test case ends.
+ */
+@TearDownTestCase(skipped = true) // Please change skipped to be false to activate this method.
+def tearDownTestCase() {
+	// Put your code here.
+}
+
+/**
+ * References:
+ * Groovy tutorial page: http://docs.groovy-lang.org/next/html/documentation/
+ */

--- a/Test Suites/Test Suite using KeywordUtil.ts
+++ b/Test Suites/Test Suite using KeywordUtil.ts
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestSuiteEntity>
+   <description></description>
+   <name>Test Suite using KeywordUtil</name>
+   <tag></tag>
+   <isRerun>false</isRerun>
+   <mailRecipient></mailRecipient>
+   <numberOfRerun>0</numberOfRerun>
+   <pageLoadTimeout>30</pageLoadTimeout>
+   <pageLoadTimeoutDefault>true</pageLoadTimeoutDefault>
+   <rerunFailedTestCasesOnly>false</rerunFailedTestCasesOnly>
+   <rerunImmediately>true</rerunImmediately>
+   <testSuiteGuid>d4edce4b-5a18-46e2-a40c-765303e441d2</testSuiteGuid>
+   <testCaseLink>
+      <guid>e6d1ba8d-8446-4d5d-8953-510d56a2fc16</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Extent Report001 using KeywordUtil</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>94c0a626-8bb0-40f9-a27f-b941e0d4da41</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Extent Report002 using KeywordUtil</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+   <testCaseLink>
+      <guid>ca14999b-29d2-409c-8058-06f6ce0a7c5b</guid>
+      <isReuseDriver>false</isReuseDriver>
+      <isRun>true</isRun>
+      <testCaseId>Test Cases/Extent Report003 using KeywordUtil</testCaseId>
+      <usingDataBindingAtTestSuiteLevel>true</usingDataBindingAtTestSuiteLevel>
+   </testCaseLink>
+</TestSuiteEntity>


### PR DESCRIPTION
# Problems to solve

The original [`Test Cases/Extent Report 001`](https://github.com/kazurayam/katalon_extentreport_sample/blob/master/Scripts/Extent%20Report001/Script1712484356586.groovy) has a code fragment like this:

```
...
WebUI.openBrowser('')
TestListenerExtentReport.extentTest.log(LogStatus.INFO, 'Browser Launched')
WebUI.navigateToUrl('https://www.google.com/')
...
```

Here I find 2 problems.

## Problem1: the code looks un-katalonic

I have never seen the code fragment `TestListenerExtentReport.extentTest.log(LogStatus.INFO,` in any other Test Case scripts. The fragment looks long and compilicated. It make me feel uneasy.. 

I would rather like to rewrite it as follows:

```
import com.kms.katalon.core.util.KeywordUtil
...
WebUI.openBrowser('')
KeywordUtil.logInfo('Browser Launched')
WebUI.navigateToUrl('https://www.google.com/')
...
```

I am used to the `com.kms.katalon.core.util.KeywordUtil` class. I know what it does. I feel relieved.

## Problem2: No message is displayed in the Log Viewer in Katalon Studio GUI

I expected a message "Browser Launched" to be displayed in the Log Viewer of Katalon Studio GUI, but it wasn't. I felt puzzled.

<img width="1072" alt="スクリーンショット 2024-04-24 16 55 39" src="https://github.com/kazurayam/katalon_extentreport_sample/assets/4467417/8b296a3c-6576-46d7-b0c1-cb756c40b5b9">

# Proposed Solution

It would be nice if a call to `KeywordUtil.logInfo('Browser Launched')` in a Test Case script can internally call `TestListenerExtentReport.extentTest.log(LogStatus.INFO, 'Browser Launched')` as well behind the scene.

This would require modifying the implementation of `KeywordUtil` class dynamically. Is it possible?

Yes, it is possible. Fortunately, `com.kms.katalon.core.util.KewyordUtil` is written in Groovy language. We can apply Groovy's "Metaprogramming" technique to dynamically modify the method implementations.

- https://www.groovy-lang.org/metaprogramming.html#_methods

# Proposed Solution

It would be nice if a call to `KeywordUtil.logInfo('Browser Launched')` in a Test Case script can internally call `TestListenerExtentReport.extentTest.log(LogStatus.INFO, 'Browser Launched')` as well behind the scene.

This would require modifying the implementation of `KeywordUtil` class dynamically. Is it possible?

Yes, it is possible. Fortunately, `com.kms.katalon.core.util.KewyordUtil` is written in Groovy language. We can apply Groovy's "Metaprogramming" technique to dynamically modify the method implementations.

- https://www.groovy-lang.org/metaprogramming.html#_methods

# Description

I modified

- [TestListenerExtentReport](https://github.com/kazurayam/katalon_extentreport_sample/blob/develop/Test%20Listeners/TestListenerExtentReport.groovy) --- implemented `modifyKeywordUtil` method which dynamically modifies the KeywordUtil class's implementation. The constructor of the TestListener class calls the `modifyKeywordUtil` method.

I added 3 Test Case scripts

- [Extent Report001 using KeywordUtil](https://github.com/kazurayam/katalon_extentreport_sample/blob/develop/Scripts/Extent%20Report001%20using%20KeywordUtil/Script1713947262025.groovy)
- [Extent Report002 using KeywordUtil](https://github.com/kazurayam/katalon_extentreport_sample/blob/develop/Scripts/Extent%20Report002%20using%20KeywordUtil/Script1713948128748.groovy)
- [Extent Report003 using KeywordUtil](https://github.com/kazurayam/katalon_extentreport_sample/blob/develop/Scripts/Extent%20Report003%20using%20KeywordUtil/Script1713950881290.groovy)

These test case scripts write 
```
KeywordUtil.logInfo('Browser Launched')
```
instead of
```
TestListenerExtentReport.extentTest.log(LogStatus.INFO, 'Browser Launched')
```

Finally, I added [Test Suites/Test Suite using KeywordUtil](https://github.com/kazurayam/katalon_extentreport_sample/blob/develop/Test%20Suites/Test%20Suite%20using%20KeywordUtil.ts)

I ran the Test Suite. See the following screenshot that shows the result of the change.

<img width="1440" alt="スクリーンショット 2024-04-24 20 04 36" src="https://github.com/kazurayam/katalon_extentreport_sample/assets/4467417/33b15e6f-aac8-4569-b4b1-888bcb5332a5">

In the "Test Cases/Extent Report001 using KeywordUtil" script, I wrote

```
KeywordUtil.logInfo('Browser Launched')
```

The message was displayed in 2 locations. One in the Log Viewer in the Katalon Studio GUI, another in the report HTML generated by ExtentReports.

